### PR TITLE
Prefer protocol agnostic href for <link>

### DIFF
--- a/header.inc.html
+++ b/header.inc.html
@@ -1,3 +1,3 @@
-<link rel="stylesheet" href="http://doc.rust-lang.org/rust.css">
+<link rel="stylesheet" href="//doc.rust-lang.org/rust.css">
 <link rel="stylesheet" href="sliderust.css">
 <script src="sliderust.js"></script>


### PR DESCRIPTION
Prevent issues with mixed-content when viewing via HTTPS
